### PR TITLE
Add: loader 플러그인화

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,9 +4,9 @@
     <div class="main-navs">
       <h3>Go to Pages:</h3>
       <ul>
-        <li><router-link to="/">Home</router-link></li>
-        <li><router-link to="/page1">Page1</router-link></li>
-        <li><router-link to="/page2">Page2</router-link></li>
+        <router-link to="/" tag="li" :class="{active: $route.matched[0].name !== 'page1'}">Home</router-link>
+        <router-link to="/page1" tag="li" :class="'actvie'">Page1</router-link>
+        <router-link to="/page2" tag="li" :class="'actvie'">Page2</router-link>
       </ul>
     </div>
     <div class="main">
@@ -16,36 +16,21 @@
 </template>
 
 <script>
-import loader from '@ibsheet/loader';
-import VueRouter from 'vue-router';
-import HelloWorld from './components/HelloWorld.vue';
-import Page1 from './components/Page1.vue';
-import Page2 from './components/Page2.vue';
-
-const router = new VueRouter({
-  mode: 'history',
-  routes: [
-    { path: '/', name: 'home', component: HelloWorld },
-    { path: '/page1', name: 'page1', component: Page1 },
-    { path: '/page2', name: 'page2', component: Page2 }
-  ]
-})
-
-loader.config({
-  registry: [{
-    name: 'ibsheet',
-    baseUrl: '/ibsheet'
-  }]
-});
-
 export default {
   name: 'app',
   data() {
     return {
-      loaderVersion: loader.version
+      loaderVersion: this.$_Loader.version
     }
   },
-  router
+  created() {
+    this.$_Loader.config({
+      registry: [{
+        name: 'ibsheet',
+        baseUrl: '/ibsheet'
+      }]
+    });
+  }
 }
 </script>
 
@@ -68,10 +53,14 @@ export default {
     > li {
       display: inline-block;
       margin: 0 10px;
-      a > {
-        color: #42b983;
-      }
+      // a > {
+      //   color: #42b983;
+      // }
     }
   }
+}
+
+.router-link-exact-active {
+  color: aquamarine
 }
 </style>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -6,9 +6,6 @@
 </template>
 
 <script>
-/* eslint-disable no-console */
-import loader from '@ibsheet/loader';
-
 export default {
   name: 'HelloWorld',
   data() {
@@ -17,7 +14,7 @@ export default {
     }
   },
   mounted() {
-    loader.unload();
+    this.$_Loader.unload();
   }
 }
 </script>

--- a/src/components/Page1.vue
+++ b/src/components/Page1.vue
@@ -6,7 +6,6 @@
 </template>
 
 <script>
-import loader from '@ibsheet/loader';
 import { SheetSampleData } from '../shared/ibsheet-data';
 
 let sheetId = '';
@@ -16,7 +15,7 @@ export default {
   mounted() {
     const { data, options } = SheetSampleData[0];
 
-    loader.createSheet({
+    this.$_Loader.createSheet({
       el: sheetEl,
       options,
       data
@@ -27,7 +26,7 @@ export default {
     });
   },
   beforeDestroy() {
-    loader.removeSheet(sheetId);
+    this.$_Loader.removeSheet(sheetId);
   }
 }
 </script>

--- a/src/components/Page2.vue
+++ b/src/components/Page2.vue
@@ -6,7 +6,6 @@
 </template>
 
 <script>
-import loader from '@ibsheet/loader';
 import { SheetSampleData } from '../shared/ibsheet-data';
 
 let sheetId = '';
@@ -16,7 +15,7 @@ export default {
   mounted() {
     const { data, options } = SheetSampleData[1];
 
-    loader.createSheet({
+    this.$_Loader.createSheet({
       el: sheetEl,
       options,
       data
@@ -27,7 +26,7 @@ export default {
     });
   },
   beforeDestroy() {
-    loader.removeSheet(sheetId);
+    this.$_Loader.removeSheet(sheetId);
   }
 }
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,13 @@
 import 'babel-polyfill';
 import Vue from 'vue';
-import VueRouter from 'vue-router';
 import App from './App.vue';
+import router from '@/router';
+import LoaderPlugin from '@/plugins/LoaderPlugin.js';
 
-Vue.use(VueRouter);
 Vue.config.productionTip = false;
+Vue.use(LoaderPlugin);
 
 new Vue({
   render: h => h(App),
+  router
 }).$mount('#app')

--- a/src/plugins/LoaderPlugin.js
+++ b/src/plugins/LoaderPlugin.js
@@ -1,0 +1,7 @@
+import loader from '@ibsheet/loader';
+
+export default {
+  install(Vue) {
+    Vue.prototype.$_Loader = loader;
+  }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,18 @@
+import Vue from 'vue';
+import VueRouter from 'vue-router';
+import HelloWorld from '@/components/HelloWorld.vue';
+import Page1 from '@/components/Page1.vue';
+import Page2 from '@/components/Page2.vue';
+
+Vue.use(VueRouter);
+
+const router = new VueRouter({
+  mode: 'history',
+  routes: [
+    { path: '/', name: 'home', component: HelloWorld },
+    { path: '/page1', name: 'page1', component: Page1 },
+    { path: '/page2', name: 'page2', component: Page2 }
+  ]
+});
+
+export default router;


### PR DESCRIPTION
Vue 에서 로더 사용시 import 해서 계속 사용하기에는 너무 불친절함. <br/>
그렇다고 Vuex 를 써서 관리하는 것보다는 플러그인화를 해서 제공하는것이 좀 더 효율적이라고 생각함. <br/>
리액트도 마찬가지로 할 수 있을 것으로 보임. <br/>
브랜치로 만들어놨는데 참고바람. (로더 create 도 라이프 싸이클 훅에서 해도 되지만, 라우터 기반에서도 제어가 가능함으로 고려해보는 것도 나쁘지 않아 보임.)